### PR TITLE
Add MediaRecordFileCreatedEvent

### DIFF
--- a/src/main/java/de/unistuttgart/iste/meitrex/common/event/MediaRecordFileCreatedEvent.java
+++ b/src/main/java/de/unistuttgart/iste/meitrex/common/event/MediaRecordFileCreatedEvent.java
@@ -1,0 +1,19 @@
+package de.unistuttgart.iste.meitrex.common.event;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+/**
+ * Event which is raised when a file for the specified media record is uploaded to MinIO.
+ */
+@Builder
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class MediaRecordFileCreatedEvent {
+    private UUID mediaRecordId;
+}


### PR DESCRIPTION
Adds the MediaRecordFileCreatedEvent, which is raised when a file for a media record is uploaded to MinIO