### PR TITLE
add annotations dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -68,23 +68,23 @@ repositories {
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa:3.4.5'
+	implementation 'org.springframework.boot:spring-boot-starter-web:3.4.5'
 	implementation 'org.springframework.boot:spring-boot-starter-graphql'
-	implementation 'jakarta.validation:jakarta.validation-api'
-	implementation 'io.dapr:dapr-sdk:1.+' // Dapr's core SDK with all features, except Actors.
-	implementation 'io.dapr:dapr-sdk-springboot:1.+' // Dapr's SDK integration with SpringBoot
-	implementation 'org.modelmapper:modelmapper:3.+'
-	implementation "io.github.kobylynskyi:graphql-java-codegen:5.+"
+	implementation 'jakarta.validation:jakarta.validation-api3.4.5'
+	implementation 'io.dapr:dapr-sdk:1.14.1' // Dapr's core SDK with all features, except Actors.
+	implementation 'io.dapr:dapr-sdk-springboot:1.14.1' // Dapr's SDK integration with SpringBoot
+	implementation 'org.modelmapper:modelmapper:3.2.3'
+	implementation "io.github.kobylynskyi:graphql-java-codegen:5.10.0"
 	implementation 'org.jetbrains:annotations:26.0.1'
-	compileOnly 'org.projectlombok:lombok'
-	developmentOnly 'org.springframework.boot:spring-boot-devtools'
-	runtimeOnly 'org.postgresql:postgresql'
-	annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
-	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testImplementation "org.mockito:mockito-core:5.+"
-	testImplementation 'org.hamcrest:hamcrest:2.+'
+	compileOnly 'org.projectlombok:lombok:1.18.38'
+	developmentOnly 'org.springframework.boot:spring-boot-devtools:3.4.5'
+	runtimeOnly 'org.postgresql:postgresql:42.7.5'
+	annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor:3.4.5'
+	annotationProcessor 'org.projectlombok:lombok:1.18.38'
+	testImplementation 'org.springframework.boot:spring-boot-starter-test:3.4.5'
+	testImplementation "org.mockito:mockito-core:5.17.0"
+	testImplementation 'org.hamcrest:hamcrest:2.2'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -70,8 +70,8 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa:3.4.5'
 	implementation 'org.springframework.boot:spring-boot-starter-web:3.4.5'
-	implementation 'org.springframework.boot:spring-boot-starter-graphql'
-	implementation 'jakarta.validation:jakarta.validation-api3.4.5'
+	implementation 'org.springframework.boot:spring-boot-starter-graphql:3.4.5'
+	implementation 'jakarta.validation:jakarta.validation-api:3.4.5'
 	implementation 'io.dapr:dapr-sdk:1.14.1' // Dapr's core SDK with all features, except Actors.
 	implementation 'io.dapr:dapr-sdk-springboot:1.14.1' // Dapr's SDK integration with SpringBoot
 	implementation 'org.modelmapper:modelmapper:3.2.3'

--- a/build.gradle
+++ b/build.gradle
@@ -76,6 +76,7 @@ dependencies {
 	implementation 'io.dapr:dapr-sdk-springboot:1.+' // Dapr's SDK integration with SpringBoot
 	implementation 'org.modelmapper:modelmapper:3.+'
 	implementation "io.github.kobylynskyi:graphql-java-codegen:5.+"
+	implementation 'org.jetbrains:annotations:26.0.1'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'org.postgresql:postgresql'

--- a/build.gradle
+++ b/build.gradle
@@ -71,7 +71,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa:3.4.5'
 	implementation 'org.springframework.boot:spring-boot-starter-web:3.4.5'
 	implementation 'org.springframework.boot:spring-boot-starter-graphql:3.4.5'
-	implementation 'jakarta.validation:jakarta.validation-api:3.4.5'
+	implementation 'jakarta.validation:jakarta.validation-api:3.1.1'
 	implementation 'io.dapr:dapr-sdk:1.14.1' // Dapr's core SDK with all features, except Actors.
 	implementation 'io.dapr:dapr-sdk-springboot:1.14.1' // Dapr's SDK integration with SpringBoot
 	implementation 'org.modelmapper:modelmapper:3.2.3'


### PR DESCRIPTION
Services could not build without the dependency.
With the added dependency the services can build now.