### PR TITLE
fix schema resolution for Strings

### DIFF
--- a/src/main/resources/graphql/scalars.graphqls
+++ b/src/main/resources/graphql/scalars.graphqls
@@ -10,3 +10,5 @@ scalar LocalTime
 scalar UUID @specifiedBy(url: "https://tools.ietf.org/html/rfc4122")
 # will be mapped to URL in Java
 scalar Url @specifiedBy(url:"https://www.w3.org/Addressing/URL/url-spec.txt")
+# will be mapped to String
+scalar JSON @specifiedBy(url:"https://www.json.org/json-en.html")


### PR DESCRIPTION
When re-fetching the Scalars from the common, i.e via the gradle tasks. The graphql builder cannot resolve the String type and instead set all String values to `JSON`, which then cannot resolved by the Java Compiler.
Fixxed by adding
```
scalar JSON @specifiedBy(url:"https://www.json.org/json-en.html")
```
