### PR TITLE
remove usage of deprecated method

### DIFF
--- a/src/main/java/de/unistuttgart/iste/meitrex/common/util/SpecificationUtil.java
+++ b/src/main/java/de/unistuttgart/iste/meitrex/common/util/SpecificationUtil.java
@@ -1,7 +1,11 @@
 package de.unistuttgart.iste.meitrex.common.util;
 
-import de.unistuttgart.iste.meitrex.generated.dto.*;
-import jakarta.persistence.criteria.*;
+import de.unistuttgart.iste.meitrex.generated.dto.DateTimeFilter;
+import de.unistuttgart.iste.meitrex.generated.dto.IntFilter;
+import de.unistuttgart.iste.meitrex.generated.dto.StringFilter;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.Expression;
+import jakarta.persistence.criteria.Root;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.lang.Nullable;
 
@@ -45,7 +49,8 @@ public class SpecificationUtil {
         }
 
         return Specification
-                .<T>where(stringEqualTo(field, stringFilter.getEquals(), stringFilter.getIgnoreCase()))
+                .<T>unrestricted()
+                .and(stringEqualTo(field, stringFilter.getEquals(), stringFilter.getIgnoreCase()))
                 .and(contains(field, stringFilter.getContains(), stringFilter.getIgnoreCase()));
     }
 


### PR DESCRIPTION
Deprecated method "where" removed. Replaced with "unspecified", as suggested by the library.