### PR TITLE
Make Dapr use custom jackson serializer

### DIFF
--- a/src/main/java/de/unistuttgart/iste/meitrex/common/config/TopicPublisherConfiguration.java
+++ b/src/main/java/de/unistuttgart/iste/meitrex/common/config/TopicPublisherConfiguration.java
@@ -1,5 +1,6 @@
 package de.unistuttgart.iste.meitrex.common.config;
 
+import de.unistuttgart.iste.meitrex.common.dapr.CustomDaprObjectSerializer;
 import de.unistuttgart.iste.meitrex.common.dapr.TopicPublisher;
 import io.dapr.client.DaprClientBuilder;
 import org.springframework.context.annotation.Bean;
@@ -11,6 +12,8 @@ import org.springframework.context.annotation.Profile;
 public class TopicPublisherConfiguration {
     @Bean
     public TopicPublisher topicPublisher() {
-        return new TopicPublisher(new DaprClientBuilder().build());
+        return new TopicPublisher(new DaprClientBuilder()
+                .withObjectSerializer(new CustomDaprObjectSerializer())
+                .build());
     }
 }

--- a/src/main/java/de/unistuttgart/iste/meitrex/common/dapr/CustomDaprObjectSerializer.java
+++ b/src/main/java/de/unistuttgart/iste/meitrex/common/dapr/CustomDaprObjectSerializer.java
@@ -1,0 +1,22 @@
+package de.unistuttgart.iste.meitrex.common.dapr;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import io.dapr.serializer.DefaultObjectSerializer;
+
+import java.io.IOException;
+
+public class CustomDaprObjectSerializer extends DefaultObjectSerializer {
+    private static final ObjectMapper mapper = new ObjectMapper()
+            .registerModule(new JavaTimeModule());
+
+    @Override
+    public byte[] serialize(Object state) throws IOException {
+        return mapper.writeValueAsBytes(state);
+    }
+
+    @Override
+    public <T> T deserialize(byte[] content, Class<T> clazz) throws IOException {
+        return mapper.readValue(content, clazz);
+    }
+}


### PR DESCRIPTION
This PR enables Dapr to use the custom jackson serializer which supports Java 8 Date & Time objects.